### PR TITLE
fix include path and build check using github action

### DIFF
--- a/.github/workflows/platformio.yml
+++ b/.github/workflows/platformio.yml
@@ -1,0 +1,24 @@
+name: Build test with platformio
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+ 
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+
+      - name: Build PlatformIO Project
+        run: pio run

--- a/lib/vl53l3c/vl53lx_platform.h
+++ b/lib/vl53l3c/vl53lx_platform.h
@@ -31,7 +31,7 @@
 #define _VL53LX_PLATFORM_H_
 
 #include <vl53lx_platform_log.h>
-#include "VL53Lx_ll_def.h"
+#include "vl53lx_ll_def.h"
 
 #define VL53LX_IPP_API
 #include <vl53lx_platform_ipp_imports.h>


### PR DESCRIPTION
Thank you for developing and maintaining this repositry. 
 
When I tried to build using platformio, I encountered following include error.  So I fixed include path. 
And I added build test using github action. 

```
$ pio run
Processing esp32-s3-devkitc-1 (platform: espressif32; board: esp32-s3-devkitc-1; framework: arduino)
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Verbose mode can be enabled via `-v, --verbose` option
CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-s3-devkitc-1.html
PLATFORM: Espressif 32 (6.7.0) > Espressif ESP32-S3-DevKitC-1-N8 (8 MB QD, No PSRAM)
HARDWARE: ESP32S3 240MHz, 320KB RAM, 8MB Flash
DEBUG: Current (esp-builtin) On-board (esp-builtin) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
PACKAGES: 
 - framework-arduinoespressif32 @ 3.20016.0 (2.0.16) 
 - tool-esptoolpy @ 1.40501.0 (4.5.1) 
 - toolchain-riscv32-esp @ 8.4.0+2021r2-patch5 
 - toolchain-xtensa-esp32s3 @ 8.4.0+2021r2-patch5
LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
LDF Modes: Finder ~ chain, Compatibility ~ soft
Found 39 compatible libraries
Scanning dependencies...
Dependency Graph
|-- FastLED @ 3.9.4
|-- INA3221 @ 0.0.1
|-- OneButton @ 2.6.1
|-- bmi270
|-- WiFi @ 2.0.0
|-- vl53l3c
|-- MdgwickAHRS
Building in release mode
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/FastLED.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/allocator.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/bilinear_expansion.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/bitswap.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/colorpalettes.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/colorutils.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/crgb.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/engine_events.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/file_system.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/five_bit_hd_gamma.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/fl/str.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/fx/detail/data_stream.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/fx/frame.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/fx/storage/bytestreammemory.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/fx/storage/filebuffer.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/fx/time.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/fx/video.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/fx/video/frame_interpolator.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/fx/video/frame_tracker.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/hsv2rgb.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/lib8tion.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/noise.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/platforms.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/platforms/esp/32/experimental/s3_clockless_and_clocked_driver.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/platforms/esp/32/i2s.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/platforms/esp/32/idf4_rmt.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/platforms/esp/32/idf4_rmt_impl.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/platforms/esp/32/idf5_rmt.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/platforms/esp/32/led_strip/configure_led.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/platforms/esp/32/led_strip/construct.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/platforms/esp/32/led_strip/led_strip_api.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/platforms/esp/32/led_strip/led_strip_rmt_dev.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/platforms/esp/32/led_strip/led_strip_rmt_encoder.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/platforms/esp/32/led_strip/rmt_strip.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/platforms/esp/32/led_strip/rmt_strip_group.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/platforms/wasm/active_strip_data.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/platforms/wasm/fs_wasm.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/platforms/wasm/js.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/platforms/wasm/timer.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/platforms/wasm/ui/button.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/platforms/wasm/ui/checkbox.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/platforms/wasm/ui/description.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/platforms/wasm/ui/events.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/platforms/wasm/ui/setup_and_loop.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/platforms/wasm/ui/slider.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/platforms/wasm/ui/title.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/platforms/wasm/ui/ui_internal.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/platforms/wasm/ui/ui_manager.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/platforms/wasm/ui/ui_number_field.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/power_mgt.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/ref.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/rgbw.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/screenmap.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/simplex.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/stub_main.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/transpose8x1_noinline.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/wiring.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/lib5a2/FastLED/xymap.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/src/alt_kalman.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/src/button.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/src/buzzer.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/src/flight_control.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/src/imu.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/src/led.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/src/main.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/src/pid.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/src/rc.cpp.o
Compiling .pio/build/esp32-s3-devkitc-1/src/sensor.cpp.o
In file included from src/flight_control.hpp:33,
                 from src/flight_control.cpp:40:
lib/vl53l3c/vl53lx_platform.h:34:10: fatal error: VL53Lx_ll_def.h: No such file or directory

***********************************************************************
* Looking for VL53Lx_ll_def.h dependency? Check our library registry!
*
* CLI  > platformio lib search "header:VL53Lx_ll_def.h"
* Web  > https://registry.platformio.org/search?q=header:VL53Lx_ll_def.h
*
***********************************************************************

 #include "VL53Lx_ll_def.h"
          ^~~~~~~~~~~~~~~~~
compilation terminated.
*** [.pio/build/esp32-s3-devkitc-1/src/flight_control.cpp.o] Error 1
In file included from src/flight_control.hpp:33,
                 from src/sensor.hpp:30,
                 from src/led.cpp:27:
lib/vl53l3c/vl53lx_platform.h:34:10: fatal error: VL53Lx_ll_def.h: No such file or directory

***********************************************************************
* Looking for VL53Lx_ll_def.h dependency? Check our library registry!
*
* CLI  > platformio lib search "header:VL53Lx_ll_def.h"
* Web  > https://registry.platformio.org/search?q=header:VL53Lx_ll_def.h
*
***********************************************************************

 #include "VL53Lx_ll_def.h"
          ^~~~~~~~~~~~~~~~~
compilation terminated.
*** [.pio/build/esp32-s3-devkitc-1/src/led.cpp.o] Error 1
In file included from src/flight_control.hpp:33,
                 from src/main.cpp:28:
lib/vl53l3c/vl53lx_platform.h:34:10: fatal error: VL53Lx_ll_def.h: No such file or directory

***********************************************************************
* Looking for VL53Lx_ll_def.h dependency? Check our library registry!
*
* CLI  > platformio lib search "header:VL53Lx_ll_def.h"
* Web  > https://registry.platformio.org/search?q=header:VL53Lx_ll_def.h
*
***********************************************************************

 #include "VL53Lx_ll_def.h"
          ^~~~~~~~~~~~~~~~~
compilation terminated.
*** [.pio/build/esp32-s3-devkitc-1/src/main.cpp.o] Error 1
In file included from src/flight_control.hpp:33,
                 from src/sensor.hpp:30,
                 from src/sensor.cpp:26:
lib/vl53l3c/vl53lx_platform.h:34:10: fatal error: VL53Lx_ll_def.h: No such file or directory

***********************************************************************
* Looking for VL53Lx_ll_def.h dependency? Check our library registry!
*
* CLI  > platformio lib search "header:VL53Lx_ll_def.h"
* Web  > https://registry.platformio.org/search?q=header:VL53Lx_ll_def.h
*
***********************************************************************

 #include "VL53Lx_ll_def.h"
          ^~~~~~~~~~~~~~~~~
compilation terminated.
*** [.pio/build/esp32-s3-devkitc-1/src/sensor.cpp.o] Error 1
In file included from src/flight_control.hpp:33,
                 from src/rc.cpp:30:
lib/vl53l3c/vl53lx_platform.h:34:10: fatal error: VL53Lx_ll_def.h: No such file or directory

***********************************************************************
* Looking for VL53Lx_ll_def.h dependency? Check our library registry!
*
* CLI  > platformio lib search "header:VL53Lx_ll_def.h"
* Web  > https://registry.platformio.org/search?q=header:VL53Lx_ll_def.h
*
***********************************************************************

 #include "VL53Lx_ll_def.h"
          ^~~~~~~~~~~~~~~~~
compilation terminated.
*** [.pio/build/esp32-s3-devkitc-1/src/rc.cpp.o] Error 1
================================================================= [FAILED] Took 4.25 seconds =================================================================
```
