### PR TITLE
fix:修复油门计算导致的零飘错误

### DIFF
--- a/src/flight_control.cpp
+++ b/src/flight_control.cpp
@@ -639,8 +639,7 @@ void get_command(void) {
         if (thlo < 0.0) thlo = 0.0;
         if (thlo > 1.0f) thlo = 1.0f;
         if ((-0.2 < thlo) && (thlo < 0.2)) thlo = 0.0f;  // 不感帯
-        th = (get_trim_duty(Voltage) + (thlo - 0.4)) * BATTERY_VOLTAGE;
-        if (th < 0) th = 0.0f;
+        th = (4.13e-3 + 3.3f * thlo - 5.44f * thlo * thlo + 3.13f * thlo * thlo * thlo) * BATTERY_VOLTAGE;
         Thrust_command = Thrust_filtered.update(th, Interval_time);
     } else if (Throttle_control_mode == 1) {
         // Auto Throttle Altitude Control


### PR DESCRIPTION
# 修复油门计算导致的错误

## 问题复现

在无人机启动之后旋翼会自动转动，且无法稳定飞行。

## 问题定位

飞控主代码中的`get_trim_duty(Voltage)`会根据当前电池电压，输出悬停占空比进行线性电压补偿，导致无人机启动之后旋翼自动旋转。

## 解决方案

改回之前的代码，把摇杆输入`thlo`到电机占空比做非线性映射，用三次多项式做矫正，让摇杆推杆的幅度和实际推力尽量成正比。

## 修复结果

修改完成后无人机在启动之后旋翼不会自动旋转，可以稳定飞行。

***如果有什么问题或需要修改的地方，请告诉我。***

> The following translation is completed by AI.

# Fixing Problems by Throttle Calculation

## Problem Reproduction

After the drone powers on, the rotors spin spontaneously and stable flight cannot be achieved.

## Root‑cause Analysis

In the main flight‑controller code, `get_trim_duty(Voltage)` outputs the hover duty cycle for linear battery‑voltage compensation. This causes the rotors to start spinning automatically upon drone startup.

## Solution

Revert to the previous implementation. Apply a cubic‑polynomial nonlinear mapping from stick input `thlo` to motor duty cycle. This calibration ensures stick‑deflection magnitude is approximately proportional to the actual thrust output.

## Fix Result

After the modification, the rotors will no longer spin spontaneously upon drone startup, and stable flight can be achieved.

***Should you have any questions or require modifications, feel free to inform me.***